### PR TITLE
fix text setter error

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ shape.draw_radius_line=True
 Only for balls, this sets whether a line from the center of the ball to the 0 degree point on the outer edge is drawn.  Defaults to False.  Can be set to True to gauge rotation of the ball. 
 
 ```python
-shape.text='Some text"
+shape.text="Some text"
 ```
 
 Only for text, this sets the text to be displayed.  This will modify the box shape around the text for collision detection. 

--- a/pyphysicssandbox/text_shape.py
+++ b/pyphysicssandbox/text_shape.py
@@ -71,7 +71,7 @@ class Text(Box):
                     body = pymunk.Body(self.body.mass, moment)
 
                 body.position = self.position
-                shape = pymunk.Poly.create_box(self.body, (width, height), self.radius)
+                shape = pymunk.Poly.create_box(body, (width, height), self.radius)
                 self.width = width
                 self.height = height
 


### PR DESCRIPTION
it will report `AssertionError: The shape's body must be added to the space before (or at the same time) as the shape.` error when using `txt.text='xxx'`